### PR TITLE
Updating 'advanced JS sc test on 3.75'

### DIFF
--- a/apps/advanced JS sc test on 3.75/functions.rsx
+++ b/apps/advanced JS sc test on 3.75/functions.rsx
@@ -23,4 +23,11 @@
     resourceName="JavascriptQuery"
     showSuccessToaster={false}
   />
+  <RESTQuery
+    id="query4"
+    resourceDisplayName="Dog API (EU)"
+    resourceName="60640093-548a-49fa-a04d-ca1e125552bb"
+    resourceNameOverride="{{ window.euResource }}"
+    resourceTypeOverride="restapi"
+  />
 </GlobalFunctions>


### PR DESCRIPTION
### Updating 'advanced JS sc test on 3.75'

This PR updates the application 'advanced JS sc test on 3.75'.

Preview all changes here: http://test.localhost:3000/tree/becca%2Fpatch-4353/apps/advanced%20JS%20sc%20test%20on%203.75
