### PR TITLE
Updating 'advanced JS sc test on 3.75'

### DIFF
--- a/apps/advanced JS sc test on 3.75/functions.rsx
+++ b/apps/advanced JS sc test on 3.75/functions.rsx
@@ -47,4 +47,11 @@
       waitType="debounce"
     />
   </RESTQuery>
+  <RESTQuery
+    id="query6"
+    resourceDisplayName="Dog API (US)"
+    resourceName="d8869b7e-fb42-458d-8da8-772ac989bc85"
+    resourceNameOverride="{{ window.usResource }}"
+    resourceTypeOverride="restapi"
+  />
 </GlobalFunctions>


### PR DESCRIPTION
### Updating 'advanced JS sc test on 3.75'

This PR updates the application 'advanced JS sc test on 3.75'.

Preview all changes here: http://test.localhost:3000/tree/becca%2Fpatch-fd7e/apps/advanced%20JS%20sc%20test%20on%203.75
